### PR TITLE
make the plugin and settings page etc

### DIFF
--- a/wp-content/plugins/jh-nyt-top-stories/admin/class-jh-nyt-top-stories-admin.php
+++ b/wp-content/plugins/jh-nyt-top-stories/admin/class-jh-nyt-top-stories-admin.php
@@ -20,7 +20,50 @@
  * @subpackage Jh_Nyt_Top_Stories/admin
  * @author     Janus Henderson <webtechteam@janushenderson.com>
  */
-class Jh_Nyt_Top_Stories_Admin {
+
+class Jh_Nyt_Top_Stories_Admin
+{
+
+	/**
+	 * wp cron event
+	 * 
+	 * @since 1.0.0
+	 */
+	const cron_event = 'jh_nyt_top_stories_cron_event';
+	/**
+	 * api url
+	 * 
+	 * @since 1.0.0	
+	 * @var string
+	 */
+	const url = 'https://api.nytimes.com/svc/topstories/v2/home.json?api-key=';
+
+	/**
+	 * option api key name
+	 * 
+	 * @since 1.0.0
+	 * @var string
+	 */
+
+	const api_key = 'jh_nyt_top_stories_api_key';
+
+	/**
+	 * option cron enable name
+	 * 
+	 * @since 1.0.0
+	 * @var 1.0.0
+	 */
+
+	const cron_enable = 'jh_nyt_top_stories_cron_enable';
+
+	/**
+	 * option cron job hour name
+	 * 
+	 * @since 1.0.0
+	 * @var 1.0.0
+	 */
+
+	const cron_hour = 'jh_nyt_top_stories_cron_hour';
 
 	/**
 	 * The ID of this plugin.
@@ -47,11 +90,11 @@ class Jh_Nyt_Top_Stories_Admin {
 	 * @param      string    $plugin_name       The name of this plugin.
 	 * @param      string    $version    The version of this plugin.
 	 */
-	public function __construct( $plugin_name, $version ) {
+	public function __construct($plugin_name, $version)
+	{
 
 		$this->plugin_name = $plugin_name;
 		$this->version = $version;
-
 	}
 
 	/**
@@ -59,7 +102,8 @@ class Jh_Nyt_Top_Stories_Admin {
 	 *
 	 * @since    1.0.0
 	 */
-	public function enqueue_styles() {
+	public function enqueue_styles()
+	{
 
 		/**
 		 * This function is provided for demonstration purposes only.
@@ -73,8 +117,7 @@ class Jh_Nyt_Top_Stories_Admin {
 		 * class.
 		 */
 
-		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/jh-nyt-top-stories-admin.css', array(), $this->version, 'all' );
-
+		wp_enqueue_style($this->plugin_name, plugin_dir_url(__FILE__) . 'css/jh-nyt-top-stories-admin.css', array(), $this->version, 'all');
 	}
 
 	/**
@@ -82,7 +125,8 @@ class Jh_Nyt_Top_Stories_Admin {
 	 *
 	 * @since    1.0.0
 	 */
-	public function enqueue_scripts() {
+	public function enqueue_scripts()
+	{
 
 		/**
 		 * This function is provided for demonstration purposes only.
@@ -96,8 +140,401 @@ class Jh_Nyt_Top_Stories_Admin {
 		 * class.
 		 */
 
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/jh-nyt-top-stories-admin.js', array( 'jquery' ), $this->version, false );
-
+		wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/jh-nyt-top-stories-admin.js', array('jquery'), $this->version, false);
 	}
 
+	/**
+	 * Register Post Type
+	 * Post Type: NYT Top Stories
+	 * 
+	 * @since 1.0.0
+	 */
+	public function register_post_types()
+	{
+		$labels = array(
+			'name'               => __( 'NYT Top Stories', 'jh-nyt-top-stories' ),
+			'singular_name'      => __( 'NYT Top Story', 'jh-nyt-top-stories' ),
+			'add_new'            => __( 'Add New', 'jh-nyt-top-stories' ),
+			'add_new_item'       => __( 'Add New NYT Top Story', 'jh-nyt-top-stories' ),
+			'edit_item'          => __( 'Edit NYT Top Story', 'jh-nyt-top-stories' ),
+			'new_item'           => __( 'New NYT Top Story', 'jh-nyt-top-stories' ),
+			'all_items'          => __( 'All NYT Top Story', 'jh-nyt-top-stories' ),
+			'view_item'          => __( 'View NYT Top Story', 'jh-nyt-top-stories' ),
+			'search_items'       => __( 'Search NYT Top Stories', 'jh-nyt-top-stories' ),
+			'not_found'          => __( 'No NYT Top Stories found', 'jh-nyt-top-stories' ),
+			'not_found_in_trash' => __( 'No NYT Top Stories found in the Trash', 'jh-nyt-top-stories' ),
+			'parent_item_colon'  => '',
+			'menu_name'          => 'NYT Top Stories'
+		);
+
+		$args = array(
+			'labels'             => $labels,
+			'description'        => '',
+			'public'             => true,
+			'exclude_from_search' => true,
+			'show_ui'            => true,
+			'query_var'          => true,
+			'rewrite'            => true,
+			'capability_type'    => 'post',
+			'has_archive'        => true,
+			'hierarchical'       => true,
+			'supports'           => array( 'title', 'revisions', 'excerpt' ),
+			'show_in_rest'       => true
+		);
+
+		register_post_type('nyt-top-story', $args);
+
+		// register Category
+		register_taxonomy(
+			'nyt_cat',
+			array( 'nyt-top-story' ),
+			array(
+				'hierarchical'          => true,
+				'label'                 => __( 'Categories', 'jh-nyt-top-stories' ),
+				'labels'                => array(
+					'name'              => __( 'NYT categories', 'jh-nyt-top-stories' ),
+					'singular_name'     => __( 'Category', 'jh-nyt-top-stories' ),
+					'menu_name'         => __( 'Categories', 'Admin menu name', 'jh-nyt-top-stories' ),
+					'search_items'      => __( 'Search categories', 'jh-nyt-top-stories' ),
+					'all_items'         => __( 'All categories', 'jh-nyt-top-stories' ),
+					'parent_item'       => __( 'Parent category', 'jh-nyt-top-stories' ),
+					'parent_item_colon' => __( 'Parent category:', 'jh-nyt-top-stories' ),
+					'edit_item'         => __( 'Edit category', 'jh-nyt-top-stories' ),
+					'update_item'       => __( 'Update category', 'jh-nyt-top-stories' ),
+					'add_new_item'      => __( 'Add new category', 'jh-nyt-top-stories' ),
+					'new_item_name'     => __( 'New category name', 'jh-nyt-top-stories' ),
+					'not_found'         => __( 'No categories found', 'jh-nyt-top-stories' ),
+				),
+				'show_ui'               => true,
+				'query_var'             => true,
+				'rewrite'               => array(
+					'slug'         => 'nyt_cat',
+					'with_front'   => false,
+					'hierarchical' => true,
+				),
+			)
+		);
+
+
+		// register Tags
+		register_taxonomy(
+			'nyt_tag',
+			array('nyt-top-story'),
+			array(
+				'hierarchical'          => false,
+				'label'                 => __('NYT tags', 'jh-nyt-top-stories'),
+				'labels'                => array(
+					'name'                       => __('NYT tags', 'jh-nyt-top-stories'),
+					'singular_name'              => __('Tag', 'jh-nyt-top-stories'),
+					'menu_name'                  => __('Tags', 'Admin menu name', 'jh-nyt-top-stories'),
+					'search_items'               => __('Search tags', 'jh-nyt-top-stories'),
+					'all_items'                  => __('All tags', 'jh-nyt-top-stories'),
+					'edit_item'                  => __('Edit tag', 'jh-nyt-top-stories'),
+					'update_item'                => __('Update tag', 'jh-nyt-top-stories'),
+					'add_new_item'               => __('Add new tag', 'jh-nyt-top-stories'),
+					'new_item_name'              => __('New tag name', 'jh-nyt-top-stories'),
+					'popular_items'              => __('Popular tags', 'jh-nyt-top-stories'),
+					'separate_items_with_commas' => __('Separate tags with commas', 'jh-nyt-top-stories'),
+					'add_or_remove_items'        => __('Add or remove tags', 'jh-nyt-top-stories'),
+					'choose_from_most_used'      => __('Choose from the most used tags', 'jh-nyt-top-stories'),
+					'not_found'                  => __('No tags found', 'jh-nyt-top-stories'),
+				),
+				'show_ui'               => true,
+				'query_var'             => true,
+				'rewrite'               => array(
+					'slug' => 'nyt_tag',
+					'with_front' => false,
+				),
+			)
+		);
+	}
+
+	/**
+	 * add plugin menu items
+	 * 
+	 * @since 1.0.0
+	 */
+
+	public function add_plugin_menu_items()
+	{
+		add_submenu_page(
+			'edit.php?post_type=nyt-top-story',
+			__( 'Settings', 'jh-nyt-top-stories' ),
+			__( 'Settings', 'jh-nyt-top-stories' ),
+			'manage_options',
+			'jh_nyt_admin_menu_settings',
+			array( $this, 'display_admin_menu_settings_page' )
+		);
+	}
+
+	/**
+	 *	edit settings page
+	 *  
+	 * @since 1.0.0
+	 */
+	public function display_admin_menu_settings_page()
+	{
+		require_once( 'partials/jh-nyt-top-stories-admin-display.php' );
+		return false;
+	}
+
+	/**
+	 * Getting the data from the api and save it
+	 * 
+	 * @since 1.0.0
+	 */
+	public static function import_stories()
+	{
+
+		try {
+			$api_key = get_option( self::api_key );
+
+			if ($api_key) {
+				
+				$url = self::url . $api_key;
+				$res = wp_remote_get(
+					$url,
+					array(
+						'timeout' => 120
+					)
+				);
+			
+				if ( is_array( $res ) && !is_wp_error( $res ) ) {
+					
+					$data = json_decode( $res["body"], true );
+					
+					if ( $data["status"] == "OK" ) {
+						$results = $data["results"];
+
+						foreach ( $results as $result ) {
+							$uri = $result["uri"];
+
+							$args = array(
+								'post_per_page' => -1,
+								'post_type' => 'nyt-top-story',
+								'post_status' => 'publish',
+								'meta_key' => '_nyt_id',
+								'meta_value' => $uri,
+								
+							);
+
+							$posts = get_posts( $args );
+							
+							if ( empty( $posts ) ) {								
+								self::save_story( $result );
+							}
+						}
+					} else {
+						return false;
+					}
+				} else {					
+					return false;
+				}
+			}
+		} catch (Exception $e) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * save story
+	 * 
+	 * @since 1.0.0
+	 */
+
+	private static function save_story( $result )
+	{
+		$title = esc_sql( $result["title"] );
+		$expert = esc_sql( $result["excerpt"] );
+		$date = $result["published_date"];
+		$url = esc_sql( $result["url"] );
+		$byline = esc_sql( $result["byline"] );
+		$category = $result["section"];
+		$tags = $result["des_facet"];
+		$uri = $result["uri"];
+		
+		
+		$post_id = wp_insert_post(
+			array(
+			'post_type' => 'nyt-top-story',
+			'post_status' => 'publish',
+			'post_excerpt' => $expert,
+			'post_modified' => strtotime( $date ),
+			'post_title' => $title,
+			'post_content' => '',
+		) );
+		
+		if ( $post_id ) {
+			update_post_meta( $post_id, 'URL', $url );
+			update_post_meta( $post_id, 'byline', $byline );
+			update_post_meta( $post_id, '_nyt_id', $uri );
+
+			self::save_taxonomy( $category, $post_id, 'nyt_cat' );
+			self::save_taxonomy( $tags, $post_id );			
+		}
+		
+	}
+
+	/**
+	 * save taxonomy
+	 * 
+	 * @since 1.0.0
+	 */
+	public static function save_taxonomy( $tags, $post_id, $taxonomy = 'nyt_tag' ) {
+		if ( is_array( $tags ) ) {
+			wp_set_object_terms( $post_id, $tags, $taxonomy );
+		} else {
+			wp_set_object_terms( $post_id, $tags, $taxonomy );
+		}
+	}
+
+	/**
+	 * get the wp options
+	 * 
+	 * @since 1.0.0
+	 */
+	public static function get_option( $field = "" )
+	{
+
+		if ( !$field ) {
+			$api_key = get_option( self::api_key );
+			$cron_enable = get_option( self::cron_enable );
+			$cron_hour = get_option( self::cron_hour );
+
+			return array(
+				'api_key' => $api_key,
+				'cron_enable' => $cron_enable,
+				'cron_hour' => $cron_hour
+			);
+		} else if ( $field == "api_key" ) {
+			return get_option( self::api_key );
+		} else if ( $field == "cron_enable" ) {
+			return get_option( self::cron_enable );
+		} else if ( $field == "cron_hour" ) {
+
+			$hour = get_option( self::cron_hour );
+
+			return !empty( $hour ) ? (int)$hour : 1;
+		}
+
+		return false;
+	}
+
+	/**
+	 * save the option
+	 * 
+	 * @since 1.0.0
+	 */
+	public static function save_option( $posts ) {
+		
+		foreach ( $posts as $key => $p ) {
+			if ( $key == "api_key" ) {
+				update_option( self::api_key, $p );
+			} else if ( $key == "cron_enable" ) {				
+				update_option( self::cron_enable, $p );				
+			} else if ( $key == "cron_hour" ) {
+				update_option( self::cron_hour, $p );
+			}
+		}
+
+		$cron_enable = isset( $posts["cron_enable"] ) ? $posts["cron_enable"] : 0;
+		$cron_hour = isset( $posts["cron_hour"] ) ? $posts["cron_hour"] : 1;
+
+		if ( $cron_enable && $cron_hour ) {
+			self::set_schedule();
+		}
+	}
+
+	/**
+	 * enable schedule
+	 * 
+	 * @since 1.0.0
+	 */
+	public static function set_schedule( ) {
+
+		wp_clear_scheduled_hook( self::cron_event );
+
+        if ( ! wp_next_scheduled( self::cron_event ) ) {
+
+            $enable = self::get_option( "cron_enable" );
+
+			if ( $enable ) {
+				$hour = self::get_option( "cron_hour" );
+				$name = ($hour == 1) ? "hourly" :  "every-$hour-hours";
+				$time = time();
+				
+				wp_schedule_event( $time, $name, self::cron_event );
+			}
+			
+            
+        } else {
+
+        }
+	}
+
+	/**
+	 * add the schedule names
+	 * 
+	 * @since 1.0.0
+	 */
+	public function add_schedule_hours( $schedules ) {
+
+		$hour = self::get_option( 'cron_hour' );		
+
+		$schedules["hourly"] = array(
+			'interval'  => 60,
+			'display'   => __( "hourly", 'jh-nyt-top-stories' )
+		);
+
+		if ( $hour > 1 ) {
+			$schedules["every-$hour-hours"] = array(
+				'interval'  => $hour * 60,
+				'display'   => __( "Every $hour hours", 'jh-nyt-top-stories' )
+			);
+		}
+		
+		return $schedules;
+	}
+
+	/**
+	 * add the schedule callback
+	 * 
+	 * @since 1.0.0
+	 */
+	public function schedule_callback() {
+		self::import_stories();
+	}
+
+	/**
+	 * add the cli
+	 * 
+	 * @since 1.0.0
+	 */
+	public function add_cli() {
+
+		WP_CLI::add_command( 'nyt_top_stories', array( $this, 'import' ) );
+	}
+
+	/**
+	 * add the command list
+	 * 
+	 * example
+	 * 		wp nyt_top_stories import
+	 * 
+	 * @since 1.0.0
+	 */
+	public function import() {
+		WP_CLI::line( 'Importing the data form ' . self::url );
+		WP_CLI::line( 'Starting...' );
+		$imported = self::import_stories();
+		if ( $imported ) {
+			WP_CLI::line( __( 'Imported top stories successfully.', 'jh-nyt-top-stories' ) );
+		} else {
+			WP_CLI::line( WP_CLI::colorize( '%r Error:%n' . __('Please check the api key or internet.', 'jh-nyt-top-stories' ) ) );
+		}
+	}
 }
+
+?>

--- a/wp-content/plugins/jh-nyt-top-stories/admin/partials/jh-nyt-top-stories-admin-display.php
+++ b/wp-content/plugins/jh-nyt-top-stories/admin/partials/jh-nyt-top-stories-admin-display.php
@@ -14,3 +14,93 @@
 ?>
 
 <!-- This file should primarily consist of HTML with a little bit of PHP. -->
+<?php
+/**
+ * get settings from wp_options
+ */
+
+// save data
+if ( isset( $_POST["save_data"] ) ) {
+    Jh_Nyt_Top_Stories_Admin::save_option(
+        array(
+            "api_key" => $_POST["api_key"],
+            "cron_enable" => isset( $_POST["cron_enable"] ) ? 1 : '',
+            "cron_hour" => $_POST["cron_hour"],
+        )
+    );
+} else if ( isset( $_POST["import"] ) ) {
+    $imported = Jh_Nyt_Top_Stories_Admin::import_stories();
+
+    if ( $imported ) {
+        echo "<div class='notice notice-success is-dismissible'><p>" . __( 'Imported top stories successfully.', 'jh-nyt-top-stories' ) . "</p></div>";    
+    } else {
+        echo "<div class='notice notice-error is-dismissible'><p>" . __( 'Error: Please check the api key or internet.', 'jh-nyt-top-stories' ) . "</p></div>";   
+    }
+}
+
+$api_key = Jh_Nyt_Top_Stories_Admin::get_option( "api_key" );
+$cron_enable = Jh_Nyt_Top_Stories_Admin::get_option( "cron_enable" );
+$cron_hour = Jh_Nyt_Top_Stories_Admin::get_option( "cron_hour" );
+
+?>
+
+<style type="text/css">
+    input[name="cron_hour"] {
+        display: none;
+    }
+
+    input[name="cron_enable"]:checked+input[name="cron_hour"] {
+        display: inline-block;
+    }
+
+    .form-table {
+        max-width: 600px;
+        width: 100%;
+    }
+
+    .form-table input[type="text"] {
+        width: 100%;
+    }
+
+    .form-table input[name="cron_hour"] {
+        width: calc(100% - 30px);
+    }
+</style>
+
+<div class="wrap">
+    <h2>
+        Settings
+    </h2>
+
+    <form method="post" action="" class="license-form">
+        <table class="form-table license-tbl">
+            <tbody>
+                <tr valign="top">
+                    <th class="licenseTable" scope="row" valign="top">
+                        <?php _e( 'NYT API Key', 'jh-nyt-top-stories' ); ?>
+                    </th>
+                    <td>
+                        <input type="text" name="api_key" value="<?php echo $api_key; ?>" />
+                    </td>
+                </tr>
+
+                <tr valign="top">
+                    <th class="cronjob" scope="row" valign="top">
+                        <?php _e( 'Cron Job', 'jh-nyt-top-stories' ); ?>
+                    </th>
+                    <td>
+                        <input type="checkbox" name="cron_enable" <?php echo $cron_enable ? "checked=checked" : ""; ?> value="1" />
+                        <input type="text" name="cron_hour" value="<?php echo $cron_hour; ?>" />
+                    </td>
+                </tr>
+
+                <tr valign="top">
+                    <th scope="row" valign="top">
+                        <input type="submit" class="button-primary" name="save_data" value="<?php _e( 'Save', 'jh-nyt-top-stories' ) ?>" />
+                        <input type="submit" class="button-secondary" id="nyt-import" name="import" value="<?php _e( 'Import', 'jh-nyt-top-stories' ) ?>" />
+                    </th>
+                </tr>
+            </tbody>
+        </table>
+    </form>
+</div>

--- a/wp-content/plugins/jh-nyt-top-stories/includes/class-jh-nyt-top-stories-activator.php
+++ b/wp-content/plugins/jh-nyt-top-stories/includes/class-jh-nyt-top-stories-activator.php
@@ -30,7 +30,7 @@ class Jh_Nyt_Top_Stories_Activator {
 	 * @since    1.0.0
 	 */
 	public static function activate() {
-
+		
 	}
 
 }

--- a/wp-content/plugins/jh-nyt-top-stories/includes/class-jh-nyt-top-stories-loader.php
+++ b/wp-content/plugins/jh-nyt-top-stories/includes/class-jh-nyt-top-stories-loader.php
@@ -42,6 +42,15 @@ class Jh_Nyt_Top_Stories_Loader {
 	protected $filters;
 
 	/**
+	 * The array of the shortcode.
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      array    $filters    The filters registered with WordPress to fire when the plugin loads.
+	 */
+	protected $shortcodes;
+
+	/**
 	 * Initialize the collections used to maintain the actions and filters.
 	 *
 	 * @since    1.0.0
@@ -50,7 +59,7 @@ class Jh_Nyt_Top_Stories_Loader {
 
 		$this->actions = array();
 		$this->filters = array();
-
+		$this->shortcodes = array();
 	}
 
 	/**
@@ -79,6 +88,22 @@ class Jh_Nyt_Top_Stories_Loader {
 	 */
 	public function add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
 		$this->filters = $this->add( $this->filters, $hook, $component, $callback, $priority, $accepted_args );
+	}
+
+	/**
+	 * Add a shortcode
+	 *
+	 * @since    1.0.0
+	 * @param    string               $shortcode_name             The name of a shortcode.
+	 * @param    object               $component        A reference to the instance of the object on which the filter is defined.
+	 * @param    string               $callback         The name of the function definition on the $component
+	 */
+	public function add_shortcode( $shortcode_name, $component, $callback ) {
+		$this->shortcodes[] = array(
+			'name'          => $shortcode_name,
+			'component'     => $component,
+			'callback'      => $callback,
+		);
 	}
 
 	/**
@@ -124,6 +149,9 @@ class Jh_Nyt_Top_Stories_Loader {
 			add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
 		}
 
+		foreach ( $this->shortcodes as $shortcode ) {
+			add_shortcode( $shortcode['name'], array( $shortcode['component'], $shortcode['callback'] ) );
+		}
 	}
 
 }

--- a/wp-content/plugins/jh-nyt-top-stories/includes/class-jh-nyt-top-stories.php
+++ b/wp-content/plugins/jh-nyt-top-stories/includes/class-jh-nyt-top-stories.php
@@ -140,7 +140,6 @@ class Jh_Nyt_Top_Stories {
 		$plugin_i18n = new Jh_Nyt_Top_Stories_i18n();
 
 		$this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
-
 	}
 
 	/**
@@ -157,6 +156,16 @@ class Jh_Nyt_Top_Stories {
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 
+		// add the register type
+		$this->loader->add_action( 'init', $plugin_admin, 'register_post_types' );
+		$this->loader->add_action( 'admin_menu', $plugin_admin, 'add_plugin_menu_items' );
+
+		// add the wp cron
+		$this->loader->add_filter( 'cron_schedules', $plugin_admin, 'add_schedule_hours' );
+		$this->loader->add_action( Jh_Nyt_Top_Stories_Admin::cron_event, $plugin_admin, 'schedule_callback' );
+
+		// add the wp cli
+		$this->loader->add_action( 'cli_init', $plugin_admin, 'add_cli');
 	}
 
 	/**
@@ -172,6 +181,8 @@ class Jh_Nyt_Top_Stories {
 
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+
+		$this->loader->add_shortcode( 'nyt_top_stories', $plugin_public, 'nyt_top_stores' );
 
 	}
 

--- a/wp-content/plugins/jh-nyt-top-stories/public/class-jh-nyt-top-stories-public.php
+++ b/wp-content/plugins/jh-nyt-top-stories/public/class-jh-nyt-top-stories-public.php
@@ -100,4 +100,55 @@ class Jh_Nyt_Top_Stories_Public {
 
 	}
 
+	/**
+	 *  show the top stories
+	 * 	[nyt_top_stories count="5" "sort"="desc"]
+	 * 
+	 * @since 1.0.0
+	 */
+	public function nyt_top_stores( $atts = array(), $conten = null ) {
+		extract(
+			shortcode_atts(
+				array(
+					'count' => '5',
+					'sort' => 'desc'
+		   		),
+			$atts)
+		);
+
+		$stories = get_posts(
+			array(
+				'numberposts' => $count,
+				'post_type' => 'nyt-top-story',
+				'post_status' => 'publish',
+				'orderby' => 'date',
+				'order' => $sort
+			)
+		);
+
+		$html = '';
+		if ( !empty( $stories ) ) {
+			ob_start();			
+			?>
+			<div class="nyt_top_stories_container">
+				<ul>
+					<?php foreach ($stories as $story):
+					$title = get_the_title( $story );
+					$link = get_post_meta( $story->ID, 'URL', true );
+					$byline = get_post_meta( $story->ID, 'byline', true );
+				 ?>
+					<li class="nyt_story_item">
+						<h3><a href="<?php echo $link; ?>" title="<?php echo $title; ?>"><?php echo $title; ?></a></h3>
+						<p><?php echo $byline; ?></p>
+					</li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+			<?php
+			$html = ob_get_clean();
+		}
+
+		return $html;
+	}
+
 }

--- a/wp-content/plugins/jh-nyt-top-stories/public/css/jh-nyt-top-stories-public.css
+++ b/wp-content/plugins/jh-nyt-top-stories/public/css/jh-nyt-top-stories-public.css
@@ -2,3 +2,26 @@
  * All of the CSS for your public-facing functionality should be
  * included in this file.
  */
+
+ .nyt_top_stories_container {
+    max-width: 100%;
+ }
+
+ .nyt_top_stories_container ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+ }
+
+ .nyt_top_stories_container .nyt_story_item{
+    margin: 0.5rem auto 1rem;    
+ }
+
+ .nyt_top_stories_container h3 {
+    font-size: 1.5rem;
+    line-height: 2rem;
+ }
+
+ .nyt_top_stories_container .nyt_story_item a {
+     font-size: inherit;
+ }


### PR DESCRIPTION
1.  registered custom post type, category and tags
2. settings pannel 
2.1 enter the api key
2.2 enable the cron job
2.3 enable the time interval (n hours)
2.4 save button => save the data to the wp_options
2.5 import button => import the data immediately
3.  make the shortcode
3.1 shortcode format: [nyt_top_stories count="5" sort="desc"]
4. impelmented the cron function
5. made a wp cli
5.1 wp nyt_top_stories import
